### PR TITLE
Color ranking icon based on player.skin

### DIFF
--- a/src/Lua/HUD/hud_leaderboard.lua
+++ b/src/Lua/HUD/hud_leaderboard.lua
@@ -29,6 +29,7 @@ local leaderboard_hud = function(v,p)
 				local tweenx = ease.outexpo(tweendiv, -400*FU, 95*FU)
 				local y = 15*FU+((i-1)*60*FU)+25*FU
 				local scale = FU*2
+				local color = v.getColormap(ldr[i].skin, ldr[i].skincolor)
 				
 				lifepatch = v.getSprite2Patch(ldr[i].skin,
 					SPR2_LIFE,
@@ -40,7 +41,7 @@ local leaderboard_hud = function(v,p)
 					scale,
 					lifepatch,
 					V_SNAPTOLEFT,
-					v.getColormap(nil,ldr[i].skincolor)
+					color
 				)
 				
 				local placepatch = v.cachePatch("LDRB_"..i)
@@ -49,7 +50,7 @@ local leaderboard_hud = function(v,p)
 					FU/2,
 					placepatch,
 					V_SNAPTOLEFT,
-					v.getColormap(nil,ldr[i].skincolor)
+					color
 				)
 				
 				v.drawString(tweenx-(lifepatch.width*scale/2),


### PR DESCRIPTION
This merge makes it so that the leaderboard properly accounts for all possible skin startcolors. This is noticable with espio, as he uses the blue palette colors as his startcolor. This merge fixes that.

Before:
![srb20454](https://github.com/Jiskster/PizzaTimeSpiceRunners/assets/45473717/2e856c99-550c-4e45-82d2-deb084ced278)

After:
![srb20455](https://github.com/Jiskster/PizzaTimeSpiceRunners/assets/45473717/fbfccf38-dd0f-47c5-baf7-019946132c94)



Color is set to "Raspberry" in both screenshots.