### PR TITLE
Player PF QOL

### DIFF
--- a/src/Lua/Hooks/PlayerThinks.lua
+++ b/src/Lua/Hooks/PlayerThinks.lua
@@ -53,6 +53,7 @@ addHook("PlayerSpawn", function(player)
 				end
 				
 				player.powers[pw_invulnerability] = 5*TICRATE
+				S_StartSound(nil, sfx_pray, player)
 			end
 		end
 	end

--- a/src/Lua/main_game.lua
+++ b/src/Lua/main_game.lua
@@ -147,6 +147,7 @@ PTSR.default_playervars = {
 	pizzachase = false,
 	pizzachase_cooldown = 0,
 	pizzachase_time = 0,
+	pizzasprint_time = 0,
 	pizzamask = nil,
 	
 	laps = 0,

--- a/src/Lua/pizzaface.lua
+++ b/src/Lua/pizzaface.lua
@@ -847,7 +847,9 @@ addHook("PlayerThink", function(player)
 			player.pizzachargecooldown = $ - 1
 		end
 
-		if PTSR.timeover and not player.realmo.pfstuntime then
+		--check for quit time, because its sorta like "camping" since we're not receiving
+		--any inputs for this PF
+		if PTSR.timeover and not (player.realmo.pfstuntime or player.quittime) then
 			local pmo = player.mo
 			local findrange = 2500*FRACUNIT
 			local zrange = 400*FU

--- a/src/Lua/pizzaface.lua
+++ b/src/Lua/pizzaface.lua
@@ -681,7 +681,7 @@ local function handle_pf_player_movement(player)
 
 			--speed up because some people like to add characters that go 700 fu/s
 			local speedboost = player.ptsr.pizzasprint_time * 1895
-			if (found_player.player.speed > PLAYPF_SPEED*found_player.scale * 3/2)
+			if (found_player.player.speed > PLAYPF_SPEED*found_player.scale * 3/2) then
 				speedboost = $ + FixedDiv(
 					found_player.player.speed - PLAYPF_SPEED*found_player.scale * 3/2,
 					found_player.scale

--- a/src/Lua/pizzaface.lua
+++ b/src/Lua/pizzaface.lua
@@ -611,6 +611,8 @@ local function controls_angle(p)
 	end
 end
 
+-- Player Pizzaface
+local PLAYPF_SPEED = 28
 local function handle_pf_player_movement(player)
 	-- handle movement
 	-- community feedback recommended us that we do this
@@ -620,13 +622,16 @@ local function handle_pf_player_movement(player)
 	player.mo.momy = 0
 	player.mo.momz = 0
 
-	local speed = 28
+	local speed = PLAYPF_SPEED
 
 	if not player.ptsr.pizzachase then
 		player.ptsr.pizzachase_cooldown = max(0, $-1)
 
 		if player.ptsr.pfbuttons & BT_CUSTOM1 then
-			speed = $*3/2
+			player.ptsr.pizzasprint_time = min($ + 1, 15*TICRATE)
+			speed = $*3/2 + (player.ptsr.pizzasprint_time * 2730)
+		else
+			player.ptsr.pizzasprint_time = $/2
 		end
 
 		if player.cmd.forwardmove or player.cmd.sidemove then
@@ -672,7 +677,21 @@ local function handle_pf_player_movement(player)
 		end
 
 		if found_player and found_player.valid then
-			P_FlyTo(player.mo,found_player.x,found_player.y,found_player.z,speed*(FU*3/2),true)
+			player.ptsr.pizzasprint_time = min($ + 1, 15*TICRATE)
+
+			--speed up because some people like to add characters that go 700 fu/s
+			local speedboost = player.ptsr.pizzasprint_time * 1895
+			if (found_player.player.speed > PLAYPF_SPEED*found_player.scale * 3/2)
+				speedboost = $ + FixedDiv(
+					found_player.player.speed - PLAYPF_SPEED*found_player.scale * 3/2,
+					found_player.scale
+				)
+			end
+			speed = ($ * FU *3/2) + speedboost
+
+			P_FlyTo(player.mo, found_player.x, found_player.y, found_player.z, speed, true)
+		else
+			player.ptsr.pizzasprint_time = 0
 		end
 
 		player.ptsr.pizzachase_time = max(0, $-1)

--- a/src/Lua/pizzaface.lua
+++ b/src/Lua/pizzaface.lua
@@ -629,7 +629,7 @@ local function handle_pf_player_movement(player)
 
 		if player.ptsr.pfbuttons & BT_CUSTOM1 then
 			player.ptsr.pizzasprint_time = min($ + 1, 15*TICRATE)
-			speed = $*3/2 + (player.ptsr.pizzasprint_time * 2730)
+			speed = $*3/2 + (player.ptsr.pizzasprint_time * 2030)
 		else
 			player.ptsr.pizzasprint_time = $/2
 		end


### PR DESCRIPTION
Yknow how zyphyr likes to add characters that go 700 fu/s, making player pf a little unfun to play, so I thought about speeding up the PF to a limit. Sprinting with C1 will gradually speed up over 15 seconds by 21.8 fu/s, this can easily be adjusted thought. When using chasedown, the PF will speed up depending on how much faster the chasee is than its max speed, i.e., if target player's speed > 42 (28*1.5), speed up by (speed - 42). Also adds the sprint boost to make chasing a little faster.

Also adds a praying sound effect when being revived 